### PR TITLE
Remove npm cache to shrink the Docker image

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Austin Riba <ariba@lco.global>
 EXPOSE 80
 
 COPY . .
-RUN npm install && npm run build
+RUN npm install && npm run build && npm cache clean --force
 
 RUN mkdir /srv/weather && cp -r dist/ index.html index.js /srv/weather
 


### PR DESCRIPTION
Removes about 20MByte from the final Docker image.