### PR TITLE
Bad column size issue -- fix for release v1.1

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -3,7 +3,7 @@
     <section class="section">
       <div class="container is-fluid">
         <div class="columns">
-          <div class="column is-one-fifth-desktop is-one-half-tablet">
+          <div class="column is-one-quarter-desktop">
             <div class="fixed">
               <WeatherNav/>
             </div>

--- a/client/src/components/NavItem.vue
+++ b/client/src/components/NavItem.vue
@@ -40,7 +40,7 @@
     display: none;
   }
   .mini-info {
-    margin-right: 3rem;
-    padding-right: 3rem;
+    margin-right: 2rem;
+    padding-right: 2rem;
   }
 </style>

--- a/client/src/components/WeatherNav.vue
+++ b/client/src/components/WeatherNav.vue
@@ -23,10 +23,10 @@
           </div>
         </div>
         <div class="columns level-left mini-info">
-          <div class="column status is-narrow heading">Open?</div>
+          <div class="column status is-one-fifth heading">Open?</div>
           <div class="column place is-two-thirds heading">Location</div>
-          <div class="column time is-narrow heading">UTC</div>
-          <div class="column mini-weather is-narrow heading">Night</div>
+          <div class="column time is-one-fifth  heading">UTC</div>
+          <div class="column mini-weather is-pulled-right heading">Night</div>
         </div>
       </div>
     </li>


### PR DESCRIPTION
I accidentally deployed the 1.1 release without realizing that since I have Chrome set to 70% zoom (laptop screen has low resolution), some of the sizing for the items wasn't correct unless you were viewing it on a high-resolution device. 

I tweaked some of the CSS and column sizes so that now it still renders correctly even on small monitors. I'll tag this as ```v1.1.1``` for release when its accepted.